### PR TITLE
Upgrade to Cats 0.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = project.in(file(".")).aggregate(coreJVM, coreJS).settings(common
   publishArtifact := false
 )
 
-val catsVersion = "0.8.1"
+val catsVersion = "0.9.0"
 
 lazy val core = crossProject.in(file(".")).
   enablePlugins(BuildInfoPlugin).

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 resolvers += "Sonatype Public" at "https://oss.sonatype.org/content/groups/public/"
 
-addSbtPlugin("org.scodec" % "scodec-build" % "1.7.0")
+addSbtPlugin("org.scodec" % "scodec-build" % "1.7.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")


### PR DESCRIPTION
Upgrade to Cats 0.9.0 and Scala 2.12.1. The Scala.js build failed with a `IRVersionNotSupportedException`. Apparently upgrading to Scala.js 0.6.14 fixes this (but I know nothing about Scala.js). However, if I understand correctly, the Scala.js version should be changed in `scodec-build` instead (?). Hence, the "do not merge", although feel free to merge if this is okay.