### PR TITLE
version bumps (mainly discipline-scalatest)

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,4 +1,3 @@
 -J-Xms2048m
 -J-Xmx2048m
--J-XX:MaxPermSize=512m
 -J-XX:ReservedCodeCacheSize=256m

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform).in(file(".")).
     libraryDependencies ++= Seq(
       "org.scodec" %%% "scodec-core" % "1.11.4",
       "org.typelevel" %%% "cats-core" % catsVersion,
-      "org.typelevel" %%% "cats-laws" % catsVersion % "test",
-      "org.typelevel" %%% "discipline-scalatest" % "1.0.0-RC1" % "test"
+      "org.typelevel" %%% "cats-laws" % catsVersion % Test,
+      "org.typelevel" %%% "discipline-scalatest" % "1.0.1" % Test,
     )
   ).
   jvmSettings(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.8

--- a/shared/src/test/scala/scodec/interop/CatsInstancesTest.scala
+++ b/shared/src/test/scala/scodec/interop/CatsInstancesTest.scala
@@ -12,9 +12,10 @@ import Arbitrary.arbitrary
 import Shrink.shrink
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import org.typelevel.discipline.scalatest.Discipline
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
+import org.scalatestplus.scalacheck.Checkers
 
-class CatsInstancesTests extends AnyFunSuite with Matchers with Discipline {
+class CatsInstancesTests extends AnyFunSuite with Matchers with Checkers with FunSuiteDiscipline {
   implicit lazy val arbBitVector: Arbitrary[BitVector] =
     Arbitrary(Gen.containerOf[Array, Byte](arbitrary[Byte]).map { b => BitVector(b) })
 


### PR DESCRIPTION
in the Scala community build, it would be helpful to me if this were
merged, since we can't (without contortions) support multiple
source-incompatible versions of discipline-scalatest