### PR TITLE
Add `Order` instances for BitVector and ByteVector

### DIFF
--- a/shared/src/main/scala/scodec/interop/cats/CatsInstances.scala
+++ b/shared/src/main/scala/scodec/interop/cats/CatsInstances.scala
@@ -19,14 +19,16 @@ private[cats] abstract class CatsInstancesLowPriority {
 
 private[cats] abstract class CatsInstances extends CatsInstancesLowPriority {
 
-  implicit val BitVectorEqInstance: Eq[BitVector] = Eq.fromUniversalEquals
+  implicit val BitVectorEqInstance: Eq[BitVector] = Eq.fromUniversalEquals // TODO: remove, deprecated by BitVectorOrderInstance
+  implicit val BitVectorOrderInstance: Order[BitVector] = Order.fromComparable[BitVector]
   implicit val BitVectorShowInstance: Show[BitVector] = Show.fromToString
   implicit val BitVectorMonoidInstance: Monoid[BitVector] = new Monoid[BitVector] {
     def empty = BitVector.empty
     def combine(x: BitVector, y: BitVector) = x ++ y
   }
 
-  implicit val ByteVectorEqInstance: Eq[ByteVector] = Eq.fromUniversalEquals
+  implicit val ByteVectorEqInstance: Eq[ByteVector] = Eq.fromUniversalEquals // TODO: remove, deprecated by ByteVectorEqInstance
+  implicit val ByteVectorOrderInstance: Order[ByteVector] = Order.fromComparable[ByteVector]
   implicit val ByteVectorShowInstance: Show[ByteVector] = Show.fromToString
   implicit val ByteVectorMonoidInstance: Monoid[ByteVector] = new Monoid[ByteVector] {
     def empty = ByteVector.empty


### PR DESCRIPTION
closes https://github.com/scodec/scodec-cats/issues/13

blocked on https://github.com/scodec/scodec/issues/245